### PR TITLE
Redesign home carousel with dark band and glassmorphism

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -46,3 +46,48 @@
   }
 }
 /* end for header logo image */
+
+/* Dark Band + Glassmorphism Carousel */
+.variations-dark-band {
+  padding: 1rem 0;
+}
+
+.variations-dark-band .variation-card {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.variations-dark-band .variation-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.3);
+}
+
+/* Active slide emphasis */
+.variations-dark-band .swiper-slide-active .variation-card {
+  transform: scale(1.03);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+/* Pagination bullets for dark background */
+.variations-dark-band .swiper-pagination-bullet {
+  background: rgba(255, 255, 255, 0.5) !important;
+}
+
+.variations-dark-band .swiper-pagination-bullet-active {
+  background: #ff6b35 !important;
+}
+
+/* Glassmorphism fallback for browsers without backdrop-blur */
+@supports not (backdrop-filter: blur(12px)) {
+  .variations-dark-band .variation-card {
+    background: rgba(30, 30, 30, 0.85);
+  }
+}
+
+/* Link colors inside dark band */
+.variations-dark-band .content a {
+  color: #ff6b35;
+}
+
+.variations-dark-band .content a:hover {
+  color: #00d4ff;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -28,6 +28,7 @@
   var testimonialOptions = {
     spaceBetween: 24,
     loop: true,
+    centeredSlides: true,
     pagination: {
       el: ".testimonial-slider-pagination",
       type: "bullets",
@@ -35,10 +36,10 @@
     },
     breakpoints: {
       768: {
-        slidesPerView: 2,
+        slidesPerView: 2.2,
       },
       992: {
-        slidesPerView: 3,
+        slidesPerView: 3.2,
       },
     },
   };

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,6 +41,58 @@
   {{ end }}
   <!-- /Banner -->
 
+  <!-- Variations -->
+  {{ with site.GetPage "sections/variations" }}
+    {{ if .Params.enable }}
+      <div class="variations-dark-band bg-gray-900 dark:bg-black">
+        <section class="section">
+          <div class="container">
+            <div class="row">
+              <div class="md:col-10 lg:col-8 xl:col-6 mx-auto mb-12 text-center">
+                <h2 class="mb-4 text-white">
+                  {{ .Title | markdownify }}
+                </h2>
+                <p class="text-gray-300">
+                  {{ .Params.description | markdownify }}
+                </p>
+              </div>
+              <div class="col-12">
+                <div class="swiper testimonial-slider">
+                  <div class="swiper-wrapper">
+                    {{ range .Params.variations }}
+                      <div class="swiper-slide">
+                        <div class="variation-card bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl px-6 pt-0 pb-8 mt-16">
+                          <div class="text-center -mt-12">
+                            <a href="{{ .avatar }}" data-featherlight="image">
+                              {{ partial "image" (dict "Src" .avatar "Class" "w-72 h-72 object-cover mx-auto rounded-xl shadow-2xl" "Alt" .name) }}
+                            </a>
+                          </div>
+                          <div class="text-center mt-4">
+                            <h3 class="h5 font-primary font-semibold mb-1 text-white">
+                              {{ .name }}
+                            </h3>
+                            <p class="text-gray-400 text-sm">
+                              {{ .designation | markdownify }}
+                            </p>
+                          </div>
+                          <p class="mt-4 text-center text-gray-300">
+                            {{ .content | markdownify }}
+                          </p>
+                        </div>
+                      </div>
+                    {{ end }}
+                  </div>
+                  <div class="testimonial-slider-pagination mt-9 flex items-center justify-center text-center"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    {{ end }}
+  {{ end }}
+  <!-- /Variations -->
+
   <!-- Features -->
   {{ range $i, $e:= .Params.features }}
     <section class="section-sm {{ if (modBool $i 2) }}bg-gradient{{ end }}">
@@ -86,68 +138,4 @@
     </section>
   {{ end }}
   <!-- /Features -->
-
-  <!-- Variations -->
-  {{ with site.GetPage "sections/variations" }}
-    {{ if .Params.enable }}
-      <section class="section">
-        <div class="container">
-          <div class="row">
-            <div class="md:col-10 lg:col-8 xl:col-6 mx-auto mb-12 text-center">
-              <h2 class="mb-4">
-                {{ .Title | markdownify }}
-              </h2>
-              <p class="content dark:text-darkmode-text-light">
-                {{ .Params.description | markdownify }}
-              </p>
-            </div>
-            <div class="col-12">
-              <div class="swiper testimonial-slider">
-                <div class="swiper-wrapper">
-                  {{ range .Params.variations }}
-                    <div class="swiper-slide">
-                      <div
-                        class="bg-light dark:bg-darkmode-light rounded-lg px-7 py-10">
-                        <!-- <div class="text-text-dark dark:text-white">
-                          <svg
-                            width="33"
-                            height="20"
-                            viewBox="0 0 33 20"
-                            fill="none"
-                            xmlns="http://www.w3.org/2000/svg">
-                            <path
-                              d="M1.28375 19.41L0.79375 18.64C1.21375 17.0067 1.75042 15.07 2.40375 12.83C3.05708 10.5433 3.75708 8.28 4.50375 6.04C5.29708 3.75333 6.06708 1.77 6.81375 0.0899959H15.3538C14.9338 2.09666 14.4904 4.26667 14.0238 6.6C13.5571 8.88666 13.1371 11.15 12.7638 13.39C12.4371 15.5833 12.1571 17.59 11.9238 19.41H1.28375ZM31.69 0.0899959L32.18 0.859998C31.76 2.54 31.2233 4.5 30.57 6.74C29.9167 8.98 29.2167 11.2433 28.47 13.53C27.7233 15.77 26.9533 17.73 26.16 19.41H17.69C18.0167 17.9167 18.3433 16.33 18.67 14.65C18.9967 12.9233 19.3 11.22 19.58 9.54C19.9067 7.81333 20.1867 6.15667 20.42 4.57C20.7 2.93666 20.91 1.44333 21.05 0.0899959H31.69Z"
-                              fill="currentColor" />
-                          </svg>
-                        </div> -->
-                        <div class="text-center mt-4">
-                          <h3 class="h5 font-primary font-semibold mb-1">
-                            {{ .name }}
-                          </h3>
-                          <p class="text-text-dark dark:text-white text-sm">
-                            {{ .designation | markdownify }}
-                          </p>
-                        </div>
-                        <div class="text-text-dark dark:text-white text-center mt-4">
-                          <a href="{{ .avatar }}" data-featherlight="image">
-                            {{ partial "image" (dict "Src" .avatar "Class" "w-60 h-60 object-cover mx-auto" "Alt" .name) }}
-                          </a>
-                        </div>
-                        <p class="mt-6 text-center">
-                          {{ .content | markdownify }}
-                        </p>
-                      </div>
-                    </div>
-                  {{ end }}
-                </div>
-                <div
-                  class="testimonial-slider-pagination mt-9 flex items-center justify-center text-center"></div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-    {{ end }}
-  {{ end }}
-  <!-- /Variations -->
 {{ end }}


### PR DESCRIPTION
## Summary
- プリンタ種類カルーセルをBanner直下に移動し、ダークバンド背景（`bg-gray-900`）で囲むことで視覚的コントラストを強化
- カードをグラスモーフィズム（すりガラス風）スタイルに変更し、画像がカード上部からはみ出すポップアウト演出を追加
- `centeredSlides` と小数値 `slidesPerView`（2.2/3.2）で隣接スライドのチラ見せ効果、ホバー浮き上がり・アクティブスライド拡大アニメーションを追加

## Test plan
- [x] `npm run build` がエラーなく完了すること
- [x] JP/EN 両方のトップページでカルーセルが正しく表示されること
- [x] ライトモード・ダークモード両方で見た目を確認
- [x] モバイル・タブレット・デスクトップでレスポンシブ表示を確認
- [x] カルーセルのスワイプ・ページネーション・autoplay が動作すること