### PR TITLE
Add browser language auto selection

### DIFF
--- a/layouts/partials/browser-language-redirect.html
+++ b/layouts/partials/browser-language-redirect.html
@@ -1,0 +1,37 @@
+{{- if hugo.IsMultilingual -}}
+{{- $translations := dict -}}
+{{- range .AllTranslations -}}
+  {{- $translations = merge $translations (dict .Lang .RelPermalink) -}}
+{{- end -}}
+{{- $currentLang := .Lang -}}
+{{- $defaultLang := site.Language.Lang -}}
+{{- with index site.Sites 0 -}}
+  {{- $defaultLang = .Language.Lang -}}
+{{- end -}}
+<script>
+  (() => {
+    const manualLangKey = "fraxinus.lang";
+    const autoCheckedKey = "fraxinus.autoLanguageChecked";
+    const currentLang = {{ $currentLang | jsonify | safeJS }};
+    const defaultLang = {{ $defaultLang | jsonify | safeJS }};
+    const translations = {{ $translations | jsonify | safeJS }};
+
+    try {
+      if (localStorage.getItem(manualLangKey)) return;
+      if (sessionStorage.getItem(autoCheckedKey)) return;
+      sessionStorage.setItem(autoCheckedKey, "1");
+    } catch {
+      return;
+    }
+
+    const browserLang = navigator.languages?.[0] || navigator.language || "";
+    const targetLang = browserLang.toLowerCase().startsWith("ja")
+      ? defaultLang
+      : "en";
+    const targetPath = translations[targetLang];
+
+    if (!targetPath || targetLang === currentLang) return;
+    location.replace(targetPath);
+  })();
+</script>
+{{- end -}}

--- a/layouts/partials/components/language-switcher.html
+++ b/layouts/partials/components/language-switcher.html
@@ -13,7 +13,9 @@
   {{ $pageTranslations.Set .Language.Lang .RelPermalink }}
 {{ end }}
 
-<select class="{{ $class }}" onchange="location = this.value">
+<select
+  class="{{ $class }}"
+  onchange="try { localStorage.setItem('fraxinus.lang', this.options[this.selectedIndex].id); } catch (e) {} location = this.value">
   {{ range site.Languages }}
     {{/* Fill the dropdown with all known languages */}}
     {{ $link := $pageTranslations.Get .Lang }}

--- a/layouts/partials/essentials/head.html
+++ b/layouts/partials/essentials/head.html
@@ -24,6 +24,7 @@
 {{ partial "basic-seo.html" . }}
 {{ partial "seo/schema.html" . }}
 
+{{ partial "browser-language-redirect.html" . }}
 
 <!-- custom script -->
 {{ partialCached "custom-script.html" . }}


### PR DESCRIPTION
## Summary
- add a Hugo partial that redirects first-time visitors to the matching translated URL based on browser language
- preserve the existing Japanese root and English /en/ URL structure
- remember manual language selector choices in localStorage to stop future automatic redirects

## Test
- npm run build